### PR TITLE
Avoid throwing if location data is unavailable.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,10 @@ var assertionVisitor = {
 		if (isThrowsMember(path.get('callee'))) {
 			var arg0 = path.node.arguments[0];
 
+			if (!(arg0 && arg0.loc && (typeof arg0.start === 'number') && (typeof arg0.end === 'number'))) {
+				return;
+			}
+
 			path.node.arguments[0] = wrapWithHelper({
 				HELPER_ID: t.identifier(this.avaThrowHelper()),
 				EXP: arg0,

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import {serial as test} from 'ava';
 import * as babel from 'babel-core';
+import * as types from 'babel-types';
 import fn from './';
 
 function transform(input) {
@@ -112,6 +113,26 @@ test('helps notThrows', t => {
 
 	t.is(code, expected);
 	addExample(input, code);
+});
+
+test('does not throw on generated code', () => {
+	var statement = types.expressionStatement(types.callExpression(
+		types.memberExpression(
+			types.identifier('t'),
+			types.identifier('throws')
+		),
+		[types.callExpression(
+			types.identifier('foo'),
+			[]
+		)]
+	));
+
+	var program = types.program([statement]);
+
+	babel.transformFromAst(program, null, {
+		plugins: [fn],
+		filename: 'some-file.js'
+	});
 });
 
 if (process.env.WRITE_EXAMPLES) {


### PR DESCRIPTION
Fixes #4 

I am not sure exactly how you end up in this scenario (and it's hard to write a test for a situation you don't know how to reproduce).

I'm guessing there was some previous transform that interfered.

@grahamb - Can you post the contents of your `.babelrc` from #4?

I would like to get a test for this if I can.
